### PR TITLE
Fix monorepo build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "preinstall": "npx -y only-allow pnpm",
-    "build": "pnpm run build -r",
+    "build": "pnpm run -r build",
     "test": "jest",
     "lint": "eslint . --ext .ts,.tsx",
     "examples:generate": "pnpm run generate --filter ./examples",


### PR DESCRIPTION
When running `pnpm run build -r`, `build -r` gets applied recursively into an infinite loop.

When running `pnpm run -r build`, pnpm recurses over worspace projects and calls the `build` command, if available.