### PR TITLE
Reference all operation responses in typedef

### DIFF
--- a/packages/cli/src/codegen/operations.ts
+++ b/packages/cli/src/codegen/operations.ts
@@ -329,7 +329,9 @@ function generateRequestFunctionType(
 
   return `export type ${requestFunctionName(
     operationId
-  )} = RequestFunction<${args}, ${generatedItems.returnType}>`;
+  )} = RequestFunction<${args}, ${
+    generatedItems.responses.operationResponses
+  }>`;
 }
 
 function getReturnType(


### PR DESCRIPTION
When defining a request response that directly references a `#/components/response`, the `returnType` does not return the expected type. I think we are looking for `generatedItems.responses.operationResponses`.