### PR TITLE
Allow recursive response components

### DIFF
--- a/packages/cli/src/codegen/components.ts
+++ b/packages/cli/src/codegen/components.ts
@@ -18,7 +18,7 @@ import {
 } from "./common";
 import { CodegenContext, CodegenRTE } from "./context";
 import { generateOperationParameter } from "./parameter";
-import { generateOperationResponse } from "./response";
+import { generateComponentResponse } from "./response";
 import { generateSchema } from "./schema";
 import * as gen from "io-ts-codegen";
 
@@ -108,12 +108,12 @@ function writeResponseFile(
   response: ParsedItem<ParsedResponse>
 ): CodegenRTE<void> {
   return pipe(
-    generateOperationResponse(response),
-    RTE.map((def) => `export const ${response.name} = ${def};`),
+    generateComponentResponse(response),
     RTE.map(
       (code) => `import * as t from "io-ts";
       import * as schemas from "../schemas";
-      
+      import * as responses from "../responses";
+
       ${code}`
     ),
     RTE.chain((content) =>

--- a/packages/cli/src/codegen/response.ts
+++ b/packages/cli/src/codegen/response.ts
@@ -1,5 +1,7 @@
 import { pipe } from "fp-ts/function";
-import { ResponseItemOrRef } from "../parser/response";
+import { ParsedItem } from "../parser/common";
+import { ParsedResponse, ResponseItemOrRef } from "../parser/response";
+import { capitalize } from "../utils";
 import { getItemOrRefPrefix, getParsedItem } from "./common";
 import { CodegenRTE } from "./context";
 import * as RTE from "fp-ts/ReaderTaskEither";
@@ -45,6 +47,41 @@ export function generateOperationResponse(
           : gen.printRuntime(type);
 
       return `{ _tag: "JsonResponse", decoder: ${runtimeType}}`;
+    })
+  );
+}
+
+export function generateComponentResponse(
+  itemOrRef: ResponseItemOrRef
+): CodegenRTE<string> {
+  return pipe(
+    getParsedItem(itemOrRef),
+    RTE.map((response: ParsedItem<ParsedResponse>) => {
+      const baseName = capitalize(response.name, "camel");
+      const schemaName = capitalize(response.name, "pascal");
+
+      if (response.item._tag === "ParsedEmptyResponse") {
+        return `export const ${schemaName} = t.never();
+
+          export const ${baseName} = { _tag: "EmptyResponse" };`;
+      }
+
+      if (response.item._tag === "ParsedFileResponse") {
+        return `export const ${schemaName} = t.never();
+
+          export const ${baseName} = { _tag: "FileResponse" };`;
+      }
+
+      const type = response.item.type;
+      const decoder = type.kind === "TypeDeclaration" ? type.type : type;
+
+      return `export const ${schemaName}: t.Type<${schemaName}> = ${gen.printRuntime(
+        decoder
+      )};
+
+        export const ${baseName} = { _tag: "JsonResponse", decoder: ${schemaName} };
+
+        export interface ${schemaName} ${gen.printStatic(decoder)};`;
     })
   );
 }

--- a/packages/cli/src/parser/schema.ts
+++ b/packages/cli/src/parser/schema.ts
@@ -4,7 +4,6 @@ import * as gen from "io-ts-codegen";
 import { OpenAPIV3 } from "openapi-types";
 import { createJsonPointer, JsonReference } from "./JSONReference";
 import { toValidVariableName } from "../utils";
-import { checkValidReference } from "./common";
 
 export function parseSchema(
   schema: OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject
@@ -67,7 +66,6 @@ function parseJsonReference(
 ): E.Either<Error, gen.TypeReference> {
   return pipe(
     createJsonPointer(pointer),
-    E.chain((jsonPointer) => checkValidReference("schemas", jsonPointer)),
     E.map((jsonPointer) => {
       const name = `${jsonPointer.tokens[2]}.${toValidVariableName(
         jsonPointer.tokens[3],


### PR DESCRIPTION
When you have responses in your spec's components that reference other component responses, these changes help:

- Ensure that the `#/components/responses/Foo` can be referenced in the response schema (i.e. by skipping reference validation)
- Ensure that the generated runtime codec is statically typed, so recursion in- or across-files does not trip up Typescript
- Standardize a mechanism to access the response decoders independently, in case response-shaped payloads are received outside of the standard HTTP client